### PR TITLE
Fix usage of serverJars api

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -55,7 +55,7 @@ fi
 
 if [ ! -f "$MC_SERVER_JAR" ]; then
     printf "\033[32m[start-server]\033[0m %s not found, downloading.\n" "${MC_SERVER_JAR}"
-    trace curl --progress-bar -L "https://serverjars.com/api/fetchJar/${MC_SERVER_TYPE}/${MC_VERSION}" -o $MC_SERVER_JAR
+    trace curl --progress-bar -L "https://serverjars.com/api/fetchJar/servers/${MC_SERVER_TYPE}/${MC_VERSION}" -o $MC_SERVER_JAR
 fi
 
 # URLs have conflicting versions, fix plugin release process first


### PR DESCRIPTION
I guess the API changed. You get a 404 html page if you use the script as is.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
